### PR TITLE
fix: Resolved Burst compiler errors (unresolved symbols on macOS) by setting correct native library reference (fixes #18)

### DIFF
--- a/Runtime/Scripts/DracoNative.cs
+++ b/Runtime/Scripts/DracoNative.cs
@@ -70,7 +70,7 @@ namespace Draco {
     [BurstCompile]
     unsafe internal class DracoNative {
         
-#if UNITY_WEBGL || UNITY_IOS
+#if !UNITY_EDITOR && (UNITY_WEBGL || UNITY_IOS)
         const string DRACODEC_UNITY_LIB = "__Internal";
 #elif UNITY_ANDROID || UNITY_STANDALONE || UNITY_WSA || UNITY_EDITOR
         const string DRACODEC_UNITY_LIB = "dracodec_unity";


### PR DESCRIPTION
@atteneder

After a few tests, I solve my issue by setting correct native library reference when we are in Unity Editor.