### PR TITLE
Task/forma draco

### DIFF
--- a/Editor/DracoEditorEncoder.cs
+++ b/Editor/DracoEditorEncoder.cs
@@ -139,7 +139,11 @@ namespace Draco.Editor {
                 var mesh = meshFilter.sharedMesh;
                 if(mesh==null) continue;
                 if (!mesh.isReadable) {
-                    Debug.LogWarning($"{mesh.name} is not readable!");
+                    Debug.LogWarning($"{mesh.name} is not readable.");
+                    continue;
+                }
+                if (mesh.subMeshCount > 1) {
+                    Debug.LogWarning($"{mesh.name} has more than one submesh. Draco compression of submeshes is not supported yet.");
                     continue;
                 }
                 

--- a/Editor/DracoEditorEncoder.cs
+++ b/Editor/DracoEditorEncoder.cs
@@ -41,7 +41,10 @@ namespace Draco.Editor {
                 submeshAssetPaths = new string[mesh.subMeshCount];
                 
                 // Get unique ids used to reference mesh and create file names out of them
-                Debug.Assert(AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID));
+                if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID))
+                {
+                    Debug.Log("Error retrieving ID for mesh {mesh.name}.");
+                }
                 var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 for (int submesh = 0; submesh < mesh.subMeshCount; submesh++) {
                     submeshFilenames[submesh] = string.Format(filename, submesh);
@@ -230,7 +233,10 @@ namespace Draco.Editor {
             }
             var dracoData = DracoEncoder.EncodeMesh(mesh);
             if (dracoData.Length > 1) {
-                Debug.Assert(AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID));
+                if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID))
+                {
+                    Debug.Log("Error retrieving ID for mesh {mesh.name}.");
+                }
                 var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 for (var submesh = 0; submesh < dracoData.Length; submesh++) {
                     File.WriteAllBytes(Path.Combine(directory,string.Format(filename,submesh)),dracoData[submesh].data.ToArray());
@@ -238,7 +244,10 @@ namespace Draco.Editor {
                 }
             }
             else {
-                Debug.Assert(AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID));
+                if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID))
+                {
+                    Debug.Log("Error retrieving ID for mesh {mesh.name}.");
+                }
                 var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 File.WriteAllBytes(Path.Combine(directory, filename), dracoData[0].data.ToArray());
                 dracoData[0].Dispose();

--- a/Editor/DracoEditorEncoder.cs
+++ b/Editor/DracoEditorEncoder.cs
@@ -123,11 +123,18 @@ namespace Draco.Editor {
             CompressMeshFilters(meshFilters.ToArray(), sceneDir);
         }
 
-        public static void CompressMeshFilters(MeshFilter[] meshFilters, string directory = null) {
+        public static void CompressMeshFilters(MeshFilter[] meshFilters, string directory = null)
+        {
+            CompressMeshFilters(meshFilters, null, directory);
+        }
+
+        public static void CompressMeshFilters(MeshFilter[] meshFilters, MeshDecoder meshDecoder, string directory = null) {
 
             var instances = new Dictionary<TextAsset, DracoDecodeInstance>();
             
-            var meshDecoder = Object.FindObjectOfType<DracoDecoder>();
+            if (meshDecoder == null) {
+                meshDecoder = Object.FindObjectOfType<DracoDecoder>();
+            }
             if (meshDecoder == null) {
                 meshDecoder = new GameObject("MeshDecoder").AddComponent<DracoDecoder>();
             }

--- a/Editor/DracoEditorEncoder.cs
+++ b/Editor/DracoEditorEncoder.cs
@@ -40,7 +40,9 @@ namespace Draco.Editor {
                 submeshFilenames = new string[mesh.subMeshCount];
                 submeshAssetPaths = new string[mesh.subMeshCount];
                 
-                var filename = string.IsNullOrEmpty(mesh.name) ? "Mesh-submesh-0.drc" : $"{mesh.name}-submesh-{{0}}.drc.bytes";
+                // Get unique ids used to reference mesh and create file names out of them
+                Debug.Assert(AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID));
+                var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 for (int submesh = 0; submesh < mesh.subMeshCount; submesh++) {
                     submeshFilenames[submesh] = string.Format(filename, submesh);
                     submeshAssetPaths[submesh] = Path.Combine(directory, submeshFilenames[submesh]);
@@ -228,14 +230,16 @@ namespace Draco.Editor {
             }
             var dracoData = DracoEncoder.EncodeMesh(mesh);
             if (dracoData.Length > 1) {
-                var filename = string.IsNullOrEmpty(mesh.name) ? "Mesh-submesh-{0}.drc.bytes" : $"{mesh.name}-submesh-{{0}}.drc.bytes";
+                Debug.Assert(AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID));
+                var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 for (var submesh = 0; submesh < dracoData.Length; submesh++) {
                     File.WriteAllBytes(Path.Combine(directory,string.Format(filename,submesh)),dracoData[submesh].data.ToArray());
                     dracoData[submesh].Dispose();
                 }
             }
             else {
-                var filename = string.IsNullOrEmpty(mesh.name) ? "Mesh.drc.bytes" : $"{mesh.name}.drc.bytes";
+                Debug.Assert(AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID));
+                var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 File.WriteAllBytes(Path.Combine(directory, filename), dracoData[0].data.ToArray());
                 dracoData[0].Dispose();
             }

--- a/Editor/DracoEditorEncoder.cs
+++ b/Editor/DracoEditorEncoder.cs
@@ -43,7 +43,7 @@ namespace Draco.Editor {
                 // Get unique ids used to reference mesh and create file names out of them
                 if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID))
                 {
-                    Debug.Log("Error retrieving ID for mesh {mesh.name}.");
+                    Debug.LogWarning("Error retrieving ID for mesh {mesh.name}.");
                 }
                 var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 for (int submesh = 0; submesh < mesh.subMeshCount; submesh++) {
@@ -128,7 +128,7 @@ namespace Draco.Editor {
             CompressMeshFilters(meshFilters, null, directory);
         }
 
-        public static void CompressMeshFilters(MeshFilter[] meshFilters, MeshDecoder meshDecoder, string directory = null) {
+        public static void CompressMeshFilters(MeshFilter[] meshFilters, DracoDecoder meshDecoder, string directory = null) {
 
             var instances = new Dictionary<TextAsset, DracoDecodeInstance>();
             
@@ -178,8 +178,7 @@ namespace Draco.Editor {
                         Debug.LogWarning($"{mesh.name} could not be encoded.");
                     }
                 }
-                else
-                {
+                else {
                     dracoMeshes.Add(dracoMesh);
                 }
             }
@@ -242,7 +241,7 @@ namespace Draco.Editor {
             if (dracoData.Length > 1) {
                 if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID))
                 {
-                    Debug.Log("Error retrieving ID for mesh {mesh.name}.");
+                    Debug.LogWarning("Error retrieving ID for mesh {mesh.name}.");
                 }
                 var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 for (var submesh = 0; submesh < dracoData.Length; submesh++) {
@@ -253,7 +252,7 @@ namespace Draco.Editor {
             else {
                 if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(mesh, out string guid, out long localID))
                 {
-                    Debug.Log("Error retrieving ID for mesh {mesh.name}.");
+                    Debug.LogWarning("Error retrieving ID for mesh {mesh.name}.");
                 }
                 var filename = $"{guid}-{localID}-{{0}}.drc.bytes";
                 File.WriteAllBytes(Path.Combine(directory, filename), dracoData[0].data.ToArray());

--- a/Runtime/Scripts/DracoDecodeInstance.cs
+++ b/Runtime/Scripts/DracoDecodeInstance.cs
@@ -13,13 +13,15 @@
 // limitations under the License.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Draco {
 
-    public class DracoDecodeInstance : ScriptableObject {
+    [Serializable]
+    public class DracoDecodeInstance {
 
         [SerializeField]
         TextAsset dracoAsset;
@@ -38,7 +40,7 @@ namespace Draco {
             mesh.name = dracoAsset.name;
     #endif
             foreach (var meshFilter in targets) {
-                meshFilter.mesh = mesh;
+                meshFilter.sharedMesh = mesh;
             }
         }
 

--- a/Runtime/Scripts/DracoDecoder.cs
+++ b/Runtime/Scripts/DracoDecoder.cs
@@ -21,10 +21,14 @@ namespace Draco {
     [ExecuteInEditMode]
     public class DracoDecoder : MonoBehaviour {
 
-        [SerializeField]
         public DracoDecodeInstance[] instances;
 
-        async void Start() {
+        async void Start()
+        {
+            await Decompress();
+        }
+
+        public async Task Decompress() {
             var startTime = Time.realtimeSinceStartup;
             var tasks = new Task[instances.Length];
             for (var i = 0; i < instances.Length; i++) {

--- a/Runtime/Scripts/DracoDecoder.cs
+++ b/Runtime/Scripts/DracoDecoder.cs
@@ -18,9 +18,10 @@ using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Draco {
-
+    [ExecuteInEditMode]
     public class DracoDecoder : MonoBehaviour {
 
+        [SerializeField]
         public DracoDecodeInstance[] instances;
 
         async void Start() {


### PR DESCRIPTION
This PR exists to make some changes required for the use of Draco Unity within Forma.

A summary of the changes worth noting follows:
- Modified warnings related to meshes that are not readable or contain submeshes to include the names of the relevant meshes. This would help the user troubleshoot compression errors.
- Instead of cancelling compression when specific meshes can not be compressed (because of readability, submeshes, etc) `CompressMeshFilters` now leaves those particular meshes uncompressed and continues to compress the others. **Maybe we want to add this ability to other apis for consistency?**
- Made `CompressMeshFilters` public and modified the signature to accept a `DracoDecoder` as input. This made retrieving the decoder from the calling function a bit cleaner.
- Modified encoder to save compressed meshes using the `GUID` and `localID` of the mesh being compressed instead of the `name` of the mesh being compressed. The previous asset names ran the risk of causing collisions when multiple meshes share a common name. This one should not cause collisions.
- Changed uses of `MeshFilter.mesh` to `MeshFilter.sharedMesh`
- Change `DracoDecodeInstance` to be a `[Serializable]` object instead of a `ScriptableObject`. `ScriptableObjects` assigned to a component like `MeshDecoder` only serialize if that component belongs to an object serialized as part of a Unity scene and not if that object is serialized as part of a prefab. This worked for the POC where a MeshDecoder object is added to the scene but not for Forma where the Decoder needs to be packaged with the product itself.
- Made decoder `[ExecuteInEditMode]` so that compressed meshes can easily be previewed in the editor. This works for us because the version of the products that we serialize is always one before the decoding has taken place. **It might pose a risk** for other users though if they aren't aware of the fact that they need to do this to avoid serializing decompressed meshes.