### PR TITLE
Support point clouds

### DIFF
--- a/Runtime/Scripts/DracoMeshLoader.cs
+++ b/Runtime/Scripts/DracoMeshLoader.cs
@@ -131,11 +131,17 @@ namespace Draco {
                 result.boneWeightData.ApplyOnMesh(unityMesh);
                 result.boneWeightData.Dispose();
             }
-            if (result.calculateNormals) {
-                unityMesh.RecalculateNormals();
-            }
-            if (requireTangents) {
-                unityMesh.RecalculateTangents();
+
+            if (unityMesh.GetTopology(0) == MeshTopology.Triangles)
+            {
+                if (result.calculateNormals)
+                {
+                    unityMesh.RecalculateNormals();
+                }
+                if (requireTangents)
+                {
+                    unityMesh.RecalculateTangents();
+                }
             }
             return unityMesh;
 #else


### PR DESCRIPTION
This addresses https://github.com/atteneder/DracoUnity/issues/16 and brings https://github.com/atteneder/glTFast/issues/135 to the 2020/MeshData api. Due to the new API the changes are also much simpler.

See https://github.com/atteneder/draco/pull/2 for the draco component.
Note this PR doesn't include updated binaries (due to prior discussion of the security non-automated-created builds).

I haven't backdated the changes to the older API (`!DRACO_MESH_DATA`) and don't have a particular interest in doing so as it was significantly messier - I don't see this as an issue as it's a new feature for a new version.

Note vertex colors do not currently work for meshes or point clouds, I have added a separate issue to track this: https://github.com/atteneder/DracoUnity/issues/27

Happy to discuss!